### PR TITLE
Add method to retrieve ORCID and Figshare account ID for users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v0.3.2](https://github.com/UAL-RE/ldcoolp-figshare/tree/v0.3.2) (2021-07-07)
+
+**Implemented enhancements:**
+ - Add method to retrieve ORCID and Figshare account ID for users
+   [#27](https://github.com/UAL-RE/ldcoolp-figshare/pull/27)
+
+**Closed issues:**
+ - Add method to retrieve ORCID and Figshare account ID for users
+   [#26](https://github.com/UAL-RE/ldcoolp-figshare/issues/26)
+
+
 ## [v0.3.1](https://github.com/UAL-RE/ldcoolp-figshare/tree/v0.3.1) (2021-07-01)
 
 **Merged pull requests:**

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2021, Arizona Board of Regents'
 author = 'Chun Ly, UA Research Data Repository (ReDATA) Team'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.3.1'
+release = 'v0.3.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/ldcoolp_figshare/__init__.py
+++ b/ldcoolp_figshare/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 from .main import FigshareInstituteAdmin

--- a/ldcoolp_figshare/main.py
+++ b/ldcoolp_figshare/main.py
@@ -106,7 +106,7 @@ class FigshareInstituteAdmin:
 
         See: https://docs.figshare.com/#private_articles_list
 
-        :param account_id: Figshare account ID
+        :param account_id: Figshare *institute* account ID
         :param process: Returns JSON content from ``redata_request``, otherwise
                         the full request is provided. Default: True
 
@@ -135,7 +135,7 @@ class FigshareInstituteAdmin:
 
         See: https://docs.figshare.com/#private_projects_list
 
-        :param account_id: Figshare account ID
+        :param account_id: Figshare *institute* account ID
         :param process: Returns JSON content from ``redata_request``, otherwise
                         the full request is provided. Default: True
 
@@ -164,7 +164,7 @@ class FigshareInstituteAdmin:
 
         See: https://docs.figshare.com/#private_collections_list
 
-        :param account_id: Figshare account ID
+        :param account_id: Figshare *institute* account ID
         :param process: Returns JSON content from ``redata_request``, otherwise
                         the full request is provided. Default: True
 
@@ -253,7 +253,7 @@ class FigshareInstituteAdmin:
 
         See: https://docs.figshare.com/#private_institution_account_group_roles
 
-        :param account_id: Figshare account ID
+        :param account_id: Figshare *institute* account ID
         :param process: Returns JSON content from ``redata_request``, otherwise
                         the full request is provided. Default: True
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='ldcoolp-figshare',
-    version='0.3.1',
+    version='0.3.2',
     packages=find_namespace_packages(),
     url='https://github.com/UAL-RE/ldcoolp-figshare/',
     project_urls={


### PR DESCRIPTION
Closes #26

Commit history:
- Add get_other_account_details method
- Minor clarification on account_id clarification [ci skip]
